### PR TITLE
FIX sort_query_element_model_list bug

### DIFF
--- a/src/Query/QueryModelBuilder.php
+++ b/src/Query/QueryModelBuilder.php
@@ -149,7 +149,7 @@ class QueryModelBuilder
             'type'
         );
 
-        $this->query_element_model_list[] = $sort_query_element;
+        $this->sort_query_element_model_list[] = $sort_query_element;
         return $this;
     }
 


### PR DESCRIPTION
sort query element model mevcut durumda query_element_model list e akleniyor, sort_quert_element_model olarak olusturulan sort query leri icin liste bos oldugundan sort yapilamiyor. Soz konusu durumum fixlendi, kontrol edip yayina alinmasini arz ederim :)